### PR TITLE
[16.0][FIX] account_payment_return: Set is_exchange to False, we only need to initialize the key, its being calculated later in _compute_payments_widget_reconciled_info

### DIFF
--- a/account_payment_return/models/account_move.py
+++ b/account_payment_return/models/account_move.py
@@ -33,12 +33,6 @@ class AccountMove(models.Model):
             payment_method_name = line_id.payment_method_line_id.name
         except AttributeError:
             payment_method_name = False
-        reconciled_partials = line_id.move_id._get_all_reconciled_invoice_partials()
-        is_exchange = any(
-            partial["is_exchange"]
-            for partial in reconciled_partials
-            if partial["aml_id"] == line_id.id
-        )
         return {
             "name": line_id.name,
             "journal_name": line_id.journal_id.name,
@@ -57,7 +51,7 @@ class AccountMove(models.Model):
             "payment_method_name": payment_method_name,
             "ref": "{} ({})".format(line_id.move_id.name, line_id.ref),
             "returned": is_return,
-            "is_exchange": is_exchange,
+            "is_exchange": False,
         }
 
     def _compute_payments_widget_reconciled_info(self):


### PR DESCRIPTION
Related to PR 767

If we set `"is_exchange": False`, is not changing the goal of the original PR.

`_compute_payments_widget_reconciled_info` method in `account_payment_return` module makes a call to `prepare_values_returned_widget` and then goes to `super()`.

In `super()`, `_compute_payments_widget_reconciled_info` core method is updating the value of `is_exchange`.

So the proposal review in original PR is Ok, as we avoid `is_exchange` calculation twice.